### PR TITLE
Fix freelance page quick links navigation routing

### DIFF
--- a/src/components/freelance/EnhancedFreelanceHub.tsx
+++ b/src/components/freelance/EnhancedFreelanceHub.tsx
@@ -541,7 +541,7 @@ export const EnhancedFreelanceHub: React.FC = () => {
                 <Button
                   variant="outline"
                   className="w-full justify-start"
-                  onClick={() => navigate('/app/analytics')}
+                  onClick={() => navigate('/app/unified-creator-studio')}
                 >
                   <BarChart3 className="w-4 h-4 mr-2" />
                   Analytics Dashboard


### PR DESCRIPTION
## Purpose
Fix non-functional quick links on the freelance page. The "View Messages" and "Analytics Dashboard" buttons were not routing to their respective pages as expected. Users needed these buttons to navigate to the chat page under the freelance tab and the unified creator analytics page.

## Code changes
- Added `onClick` handlers to the "View Messages" and "Analytics Dashboard" buttons in `EnhancedFreelanceHub.tsx`
- "View Messages" button now routes to `/app/chat`
- "Analytics Dashboard" button now routes to `/app/unified-creator-studio`
- Moved `useNavigate` import to the top of the imports for better organization

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 104`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2fbe2f82e1af4de1b096a87b8950f7b0/zen-forge)

👀 [Preview Link](https://2fbe2f82e1af4de1b096a87b8950f7b0-zen-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2fbe2f82e1af4de1b096a87b8950f7b0</projectId>-->
<!--<branchName>zen-forge</branchName>-->